### PR TITLE
[47기 하준수] Add: 날짜별 예약가능인원 조회 기능 추가 (feature/order-capacitycheck)

### DIFF
--- a/api/controllers/likesController.js
+++ b/api/controllers/likesController.js
@@ -7,7 +7,6 @@ const getLikes = catchAsync(async (req, res) => {
   return res.status(200).json({ data: likes });
 });
 
-
 const createLikes = catchAsync(async (req, res) => {
   const userId = req.user.id;
   const targetId = req.params.targetId;

--- a/api/controllers/orderController.js
+++ b/api/controllers/orderController.js
@@ -24,4 +24,12 @@ const orderWithPoint = catchAsync(async (req, res) => {
   return res.status(201).json({ message: "RESERVATION_SUCCESS" });
 });
 
-module.exports = { orderWithPoint };
+const checkCapacity = catchAsync(async (req, res) => {
+  const storeActivityId = req.params.storeActivityId;
+
+  const capacityList = await orderService.capacityListCheck(storeActivityId);
+
+  res.status(200).json({ capacityList });
+});
+
+module.exports = { orderWithPoint, checkCapacity };

--- a/api/routes/orderRouter.js
+++ b/api/routes/orderRouter.js
@@ -5,5 +5,6 @@ const { loginRequired } = require("../utils/auth");
 const router = express.Router();
 
 router.post("/point", loginRequired, orderController.orderWithPoint);
+router.get("/capacitycheck/:storeActivityId", orderController.checkCapacity);
 
 module.exports = router;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 데이터베이스 작업
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 - 해당 브랜치(PR)에서 구현하고자 하는 하나의 목표 작성
- 엔드유저는 store activity에 대해 일자별로 예약할 수 있는 인원정보를 조회할 수 있다.

<br />

## :: 구현 사항 설명 - 해당 브랜치(PR)에서 작업한 내용 작성
1. 패스파라미터로서의 storeActivityId정보를 가져온 뒤 넘겨준다. 컨트롤러 레벨에서 api실행 시점의 날짜데이터를 정제하여 다음 레벨로 넘겨준다.
2. 가져온 정보를 통해 조회 기준 1일이 지난 후 ~ 2주 간 해당 stroeActivityId에 대해 예약할 수 있는 인원수를 DB의 orders 테이블을 근거로 조회한다.
3. 해당 일자별 예약가능 인원수를 리스폰스로 전달한다.

<br />

## :: 테스트 결과 이미지
1. Server가 잘 동작하는지 확인할 수 있는 Terminal 캡쳐 이미지
<img width="1019" alt="image" src="https://github.com/wecode-bootcamp-korea/47-2nd-gabozaGo-backend/assets/135545450/a1c118d7-d12b-4f02-87f2-ab1cc996b483">

2. Postman(Client Tool)을 이용한 API 테스트 결과 이미지
2-1. 정상작동의 경우
![image](https://github.com/wecode-bootcamp-korea/47-2nd-gabozaGo-backend/assets/135545450/93319bd0-50a7-46f8-b8ab-e68277c9920f)

2-2. 예외처리(없는 storeActivityId의 경우)
![image](https://github.com/wecode-bootcamp-korea/47-2nd-gabozaGo-backend/assets/135545450/35e1f055-9524-4e43-91a7-8085cede771a)


3. 작성한 Test Code가 잘 통과했는지 확인할 수 있는 이미지
- N/A
4.  DB 작업 PR인 경우 Table 생성 및 수정 결과에 대해 확인할 수 있는 이미지
- N/A
<br />

## :: 기타 질문 및 특이 사항
N/A
